### PR TITLE
Using service command vs status command.

### DIFF
--- a/check_upstart_status.pl
+++ b/check_upstart_status.pl
@@ -56,7 +56,7 @@ my $goal;
 my $state;
 
 #Run command and get result
-my $cmd = "status $jobName";
+my $cmd = "service $jobName status";
 $retval = `$cmd`;
 
 #Get return code


### PR DESCRIPTION
I was having a problem on ubuntu 14.04 where the service command wouldn't be able to find the haproxy job.  I switch the code to use "service [jobname] status" and now its working for all the jobs.  I'm not an upstart master, so if this change is bad please let me know.  But it seems to be working for me.  Thanks for putting this up, it saved me a bunch of time.
-James
